### PR TITLE
Fix for manual versioning with local whl file builds

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -334,9 +334,12 @@ $ pip uninstall devex_sdk
 ### Build _.whl_ File
 Navigate to the root of the _devex_sdk_ directory you have been working in on your local host.  Then issue the following command:
 ```console
-~/devex_sdk$ python setup.py bdist_wheel
+~/devex_sdk$ python setup.py bdist_wheel --version <VERSION_NUMBER>
 ```
 This will generate the .whl file in the _dist_ directory at the root of the _devex_sdk_ file structure.
+
+**NOTE**: the ***<VERSION_NUMBER>*** only effects your local build.  You can use any version number you like.  This can be helpful in testing prior to submitting a pull request.  Alternatively, you can eclude the ***--version <VERSION_NUMBER>*** flag and the .whl file name will output as ***devex_sdk-_VERSION_PLACEHOLDER_-py3-none-any.whl***
+
 ### Install New _.whl_ File
 Next, from the same directory, execute the following command:
 ```console

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,32 +11,32 @@ Perform the following commands within your _devex_sdk_ repository:
 
 1. Get a fresh pull on the the _devex_sdk_ repository:
 ```console
-$ git pull
+git pull
 ```
 
 2. Next, create a branch from _main_ on your local machine by executing following command; you will need to replace the fields with your first name and the name of your algorithm:
 ```console
-$ git branch firstname/name_of_algo
+  git branch firstname/name_of_algo
 ```
 __For Example__: If Vinny put together a brand-new algorithm for creating buckets with EKS data, his branch and command would look as follows:
 ```console
-$ git branch vinny/bucketization
+ git branch vinny/bucketization
 ```
 3. Now, you are still working in the _main_ branch on your local machine.  This can be confirmed by issuing the _branch_ command which will show the current branch as highlighted:
 ```console
-$ git branch
+ git branch
 ```
 4. You will now need to switch your branch to the new branch you created.  To do this, execute the following command, replacing _firstname/name_of_algo_ with your previously defined branch name:
 ```console
-$ git switch firstname/name_of_algo
+ git switch firstname/name_of_algo
 ```
 5. Confirm you are now working in your branch by issuing the branch command:
 ```console
-$ git branch
+ git branch
 ```
 6. Now, you will need to push your current branch and set it as the upstream equivalent.  This will add your branch held on your local machine to the repository online:
 ```console
-$ git push --set-upstream origin firstname/name_of_algo
+ git push --set-upstream origin firstname/name_of_algo
 ```
 
 ### Adding Your Algorithm to The Directory Hierarchy
@@ -308,8 +308,8 @@ When your test functions are complete, you can run the test cases by navigating 
 RUN: pytest from root dir.
 RUN pytest --slow from root dir to run slow tests.
 ```console
-~/devex_sdk$ pytest
-~/devex_sdk$ pytest --slow
+pytest
+pytest --slow
 ```
 ```
 In order to run tests locally please change the bucket_name and folder_name to either local data or s3 stored data.
@@ -329,12 +329,12 @@ It is time for a test build!  If you've followed the steps above, and your unit 
 ### Uninstall _devex_sdk_ from Local Host
 Issue the following command in your terminal to remove the existing install of _devex_sdk_:
 ```console
-$ pip uninstall devex_sdk
+ pip uninstall devex_sdk
 ```
 ### Build _.whl_ File
 Navigate to the root of the _devex_sdk_ directory you have been working in on your local host.  Then issue the following command:
 ```console
-~/devex_sdk$ python setup.py bdist_wheel --version <VERSION_NUMBER>
+  python setup.py bdist_wheel --version <VERSION_NUMBER>
 ```
 This will generate the .whl file in the _dist_ directory at the root of the _devex_sdk_ file structure.
 
@@ -343,14 +343,14 @@ This will generate the .whl file in the _dist_ directory at the root of the _dev
 ### Install New _.whl_ File
 Next, from the same directory, execute the following command:
 ```console
-~/devex_sdk$ pip install /dist/*.whl
+  pip install /dist/*.whl
 ```
 **Note:** in Windows, you will need to hit ___tab___ prior to executing the above command, this will autocomplete the name of the _.whl_ file. 
 
 ### Test the Sub-Package
 Now navigate to your home directory to get out of the _devex_sdk_ folder, this will ensure that you are testing _devex_sdk_ off of the pip installed version, not the _devex_sdk_ directory:
 ```console
-$ cd ~
+ cd ~
 ```
 Now, enter a Python Environment and test your sub-package.  Try various levels of imports, test all the features, and ensure everything is behaving as it should.  For example, the _cricles_ sub-packge would be tested as follows
 ```console

--- a/README.md
+++ b/README.md
@@ -12,16 +12,18 @@ pip install git+https://github.com/DISHDevEx/dish-devex-sdk.git
 ### __Installing devex_sdk__ from local build (beta testing):
 1. Navigate into the root _devex_sdk_ directory.
 ```console
-$ cd dish-devex-sdk
+cd dish-devex-sdk
 ```
 2. Run the following command to create the wheel file
  
 ```console
-$ python setup.py bdist_wheel
+python setup.py bdist_wheel --version <VERSION_NUMBER>
 ```
+**NOTE**: the ***<VERSION_NUMBER>*** only effects your local build.  You can use any version number you like.  This can be helpful in testing prior to submitting a pull request.  Alternatively, you can eclude the ***--version <VERSION_NUMBER>*** flag and the .whl file name will output as ***devex_sdk-_VERSION_PLACEHOLDER_-py3-none-any.whl***
+
 3. Next, pip install the wheel file by running the following command, note that the _version_ will change depending upon the release:
 ```console
-$ pip install /dist/devex_sdk-(version)-py3-non-any.whl
+pip install /dist/devex_sdk-<VERSION_NUMBER>-py3-none-any.whl
 ```
 ### __Usage__
 

--- a/setup.py
+++ b/setup.py
@@ -3,11 +3,43 @@ Build the wheel file for the library devex_sdk.
 """
 
 from setuptools import find_packages, setup
-
+from sys import argv
 
 from pathlib import Path
 this_directory = Path(__file__).parent
 long_description = (this_directory / "README.md").read_text()
+
+# Pierce, working with command line arguments
+
+# total arguments
+def total_args():
+    n = len(sys.argv)
+    print("Total arguments passed:", n)
+
+
+# Arguments passed
+def list_args():
+    print("\nName of Python script:", sys.argv[0])
+
+    print("\nArguments passed:", end=" ")
+    for i in range(1, n):
+        print(sys.argv[i], end=" ")
+
+
+# def get_version(rel_path):
+#     for line in read(rel_path).splitlines():
+#         if line.startswith('__version__'):
+#             delim = '"' if '"' in line else "'"
+#             return line.split(delim)[1]
+#     else if ('{{VERSION_PLACEHOLDER}}')
+#     else:
+#         raise RuntimeError("Unable to find version string.")
+
+# Pierce additions
+total_args()
+list_args()
+
+# End Pierce additions
 
 setup(
     name='devex_sdk',

--- a/setup.py
+++ b/setup.py
@@ -3,47 +3,59 @@ Build the wheel file for the library devex_sdk.
 """
 
 from setuptools import find_packages, setup
-from sys import argv
+import sys
 
 from pathlib import Path
 this_directory = Path(__file__).parent
 long_description = (this_directory / "README.md").read_text()
 
-# Pierce, working with command line arguments
 
-# total arguments
-def total_args():
-    n = len(sys.argv)
-    print("Total arguments passed:", n)
+def get_version():
+    """
+    Checks commandline arguments for a user specified Version number.
+    If the --version flag is not given at run time, then the version number is defaulted to
+    {{VERSION_PLACEHOLDER}}, which will later be replaced with a git tag when performing
+    version releases.
+
+    Returns
+    -------
+    when the bdist_wheel command is given a version flag and version number, such as:
+
+    --version 1.x.x
+
+    the version of the built whl file will include the given version number, such as:
+
+    devex_sdk-1.x.x-py3-none-any.whl
 
 
-# Arguments passed
-def list_args():
-    print("\nName of Python script:", sys.argv[0])
+    Error Handling
+    --------------
+    If the --version flag is given, but no version number is supplied, such as:
 
-    print("\nArguments passed:", end=" ")
-    for i in range(1, n):
-        print(sys.argv[i], end=" ")
+    --version
+
+    then an IndexError will be thrown and the build will exit with exit status 1.
+
+    """
+    version = '{{VERSION_PLACEHOLDER}}'
+    if "--version" in sys.argv:
+        try:
+            version = sys.argv[3]
+            sys.argv.remove(sys.argv[3])
+        except IndexError as e:
+            print("error:  " + str(e))
+            print("supply a version number i.e. --version 1.x.x")
+            exit(1)
+        sys.argv.remove("--version")
+    return version
 
 
-# def get_version(rel_path):
-#     for line in read(rel_path).splitlines():
-#         if line.startswith('__version__'):
-#             delim = '"' if '"' in line else "'"
-#             return line.split(delim)[1]
-#     else if ('{{VERSION_PLACEHOLDER}}')
-#     else:
-#         raise RuntimeError("Unable to find version string.")
+version_var = str(get_version())
 
-# Pierce additions
-total_args()
-list_args()
-
-# End Pierce additions
 
 setup(
     name='devex_sdk',
-    version='{{VERSION_PLACEHOLDER}}',
+    version=version_var,
     description='Dish DevEx open source SDK',
     url='https://git-codecommit.us-west-2.amazonaws.com/v1/repos/devex_sdk',
     author_email='devex@dish.com',


### PR DESCRIPTION
Hi Hamza and Praveen,

I put together some logic in the **_setup.py_** file that resolves the versioning issue.  The method is called _**get_version**_.  What this method allows is the following:

1. Automatic GitHub Releases and PyPi releases with the same version number, based on the _git tag_ still works as expected.  I just tried this out with a version number of v0.1.1-beta ([GitHub](https://github.com/DISHDevEx/dish-devex-sdk/releases/tag/v0.1.1-beta)) ([PyPi](https://pypi.org/project/devex-sdk/0.1.1b0/))
2. During local builds, the developer can choose to specify a version number.  This can be done using a _**--version <VERSION_NUMBER>**_ flag when running the _python setup.py bdist_wheel_ command.  This new option is documented both in the [README](https://github.com/DISHDevEx/dish-devex-sdk/blob/pierce/whl-versioning/README.md#installing-devex_sdk-from-local-build-beta-testing) and [CONTRIBUTING](https://github.com/DISHDevEx/dish-devex-sdk/blob/pierce/whl-versioning/CONTRIBUTING.md#build-whl-file)

**_EXAMPLE:_**
running:

python setup.py bdist_wheel --version v0.1.1-beta

will result in a whl file being built with the following name:

devex_sdk-v0.1.1-beta-py3-none-any.whl

If the developer chooses to not supply a version number, and simply runs _**python setup.py bdist_wheel**_, then the locally built .whl file will have the following name, every time, and the previous build will be over-written:

devex_sdk-_VERSION_PLACEHOLDER_-py3-none-any.whl