### PR TITLE
Update path prefix for gz connector

### DIFF
--- a/devex_sdk/data_ingestion/README.md
+++ b/devex_sdk/data_ingestion/README.md
@@ -78,14 +78,15 @@ How to use:
 from devex_sdk import GzConnector
 
 log_type = 'application'
-bucket = 'open5gs-respons-logs'
+bucket = 'test-bucket'
+cluster = 'test-cluster'
 year = '2023'
 month = '05'
-day = '02'  
+day = '18'  
 hour = '14'
 
-gzc = GzConnector(bucket=bucket, log_type=log_type, year=year,
-                  month=month, day=day, hour=hour, 
+gzc = GzConnector(bucket=bucket, log_type=log_type, cluster=cluster,
+                  year=year, month=month, day=day, hour=hour, 
                   perf_rec_type=perf_rec_type,
                   cp_log_type=cp_log_type)
 

--- a/devex_sdk/data_ingestion/gz_connector.py
+++ b/devex_sdk/data_ingestion/gz_connector.py
@@ -61,17 +61,19 @@ class GzConnector():
             Filter dataframe by column(s).
     """
 
-    def __init__(self, bucket, log_type, year, month, day, hour, perf_rec_type=None):
+    def __init__(self, bucket, log_type, cluster, year, month, day, hour, perf_rec_type=None):
         """
         Construct all the necessary parameters for the GzConnector object.
         """
         self.bucket = bucket
         self.log_type = log_type
+        self.cluster = cluster
         self.perf_rec_type = perf_rec_type
-        self.prefix = f'{log_type}-logs/{year}/{month}/{day}/{hour}'
+        self.prefix = f'{log_type}-logs/{cluster}/{year}/{month}/{day}/{hour}'
         if log_type == 'performance':
             self.prefix = f'lambdatest/performance/{year}/{month}/{day}/{hour}'
         if log_type == 'test':
+            self.cluster = None
             self.year = None
             self.month = None
             self.day = None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -139,7 +139,7 @@ def Dask_dd():
 # Fixtures to test GzConnector
 @pytest.fixture(scope='module')
 def gzc():
-    return GzConnector(bucket=gz_bucket_name, log_type='test',
+    return GzConnector(bucket=gz_bucket_name, log_type='test', cluster = None,
                        year=None, month=None, day=None, hour=None,
                        perf_rec_type=None)
 

--- a/tests/test_gz_connector.py
+++ b/tests/test_gz_connector.py
@@ -1,4 +1,5 @@
 from devex_sdk import GzConnector
+from .commons import gz_bucket_name
 
 def test_get_paths(gzc, get_paths_expected):
     actual_result = gzc.get_paths()
@@ -10,7 +11,7 @@ def test_get_objects(gzc, get_paths_expected, get_objects_expected):
     assert actual_result == get_objects_expected
 
 def test_process_objects(gzc, s3_resource, process_objects_expected):
-    obj = [s3_resource.Object(bucket_name='open5gs-respons-logs', key='pytest/gz_files/test.gz')]
+    obj = [s3_resource.Object(bucket_name=gz_bucket_name, key='pytest/gz_files/test.gz')]
     actual_result = gzc.process_objects(obj)
     assert actual_result == process_objects_expected
 
@@ -19,9 +20,9 @@ def test_initial_df(gzc, process_objects_expected, inital_df_expected):
     assert actual_result.equals(inital_df_expected)
 
 def test_initial_df_performance(gzc, performance_contents, initial_df_performance_expected):
-    gzc = GzConnector(bucket='open5gs-respons-logs', log_type='test',
-                  year=None, month=None, day=None, hour=None, 
-                  perf_rec_type='test')
+    gzc = GzConnector(bucket=gz_bucket_name, log_type='test',
+                  cluster = None, year=None, month=None, day=None, 
+                  hour=None, perf_rec_type='test')
     actual_result = gzc.initial_df_performance(performance_contents)
     assert actual_result.equals(initial_df_performance_expected)
 


### PR DESCRIPTION
Updated gz connector path prefix with cluster name to read in logs from the new s3 structure.

Files modified: 
- devex_sdk/data_ingestion/gz_connector.py
- tests/conftest.py
- tests/test_gz_connector.py
- devex_sdk/data_ingestion/README.md